### PR TITLE
Use correct field name in dropdown to fix the dropdown issue in 'Average Durations' panel

### DIFF
--- a/default/data/ui/views/3cx_queue_overview.xml
+++ b/default/data/ui/views/3cx_queue_overview.xml
@@ -332,8 +332,8 @@ $tkn_only_internal_call_seq$
       <input type="dropdown" token="savgs" searchWhenChanged="true">
         <label></label>
         <choice value="tot_ringing_sec">Average Customer Ring Time</choice>
-        <choice value="tot_servicing_sec">Average Customer Talk Time</choice>
-        <choice value="tot_polling_sec">Average Customer Poll Time</choice>
+        <choice value="ts_servicing_sec">Average Customer Talk Time</choice>
+        <choice value="ts_polling_sec">Average Customer Poll Time</choice>
         <default>tot_ringing_sec</default>
         <initialValue>tot_ringing_sec</initialValue>
       </input>


### PR DESCRIPTION
Jira: SCX-15

Changes:
* Use correct field name in dropdown to fix the dropdown issue in 'Average Durations' panel
